### PR TITLE
remove hint "nào"

### DIFF
--- a/components/HintCheckboxList.vue
+++ b/components/HintCheckboxList.vue
@@ -1,7 +1,10 @@
 <template>
   <ul class="flex list-none flex-col gap-2 overflow-auto px-4">
     <li v-for="(hint, hint_index) in displayed_hints" :key="hint">
+      <!-- NOTE: The v-if below just to make sure the app still works properly
+      After removing a Hint from Hint List. Remove this if not needed. -->
       <div
+        v-if="hint.hint_index < aInput.hints.all_hints.length"
         :class="[
           addition_info[hint_index].checked_percent >= RED_THRESHHOLD
             ? 'opacity-50'

--- a/stores/annotationInput.js
+++ b/stores/annotationInput.js
@@ -18,7 +18,6 @@ export const useAnnotationInputStore = defineStore("annotation_input", {
           'Câu hỏi phải bao gồm từ "Và" hoặc các từ đồng nghĩa',
           'Câu hỏi phải bao gồm từ "Hoặc" hoặc các từ đồng nghĩa',
           'Câu hỏi phải bao gồm từ "Không" hoặc các từ đồng nghĩa',
-          'Câu hỏi phải bao gồm từ "Nào" hoặc các từ đồng nghĩa',
           'Câu hỏi phải bao gồm từ "Thuộc" hoặc các từ đồng nghĩa',
           'Câu hỏi phải bao gồm từ "Ở đâu" hoặc các từ đồng nghĩa',
           'Câu hỏi phải bao gồm từ "Khi nào" hoặc các từ đồng nghĩa',


### PR DESCRIPTION
Update:
- Remove hint "Nào".
- Make Display Hint Checkbox displays properly (because it relies on current_hints_set, the set is not updated and still remains like it was before, we add the "if" so it will render only these hints that still in the list ` hint.hint_index < aInput.hints.all_hints.length`).